### PR TITLE
fixing bug to correctly display OMEGA correlations in printParamTable

### DIFF
--- a/R/addEstFormat.R
+++ b/R/addEstFormat.R
@@ -57,7 +57,7 @@ addEstFormat <- function(pars,source.ci="cov",rse.cov){
 
     
     ## pars[panel=="OMEGAcorr"&FIX==0,tab.est:=sprintf("%s [%s] (%s)",signif(est,3),tab.corr,tab.rse)]
-    pars[panel=="OMEGA"&i!=j&FIX==0,tab.est:=sprintf("%s [%s]",signif(est,3),tab.corr)]
+    pars[panel=="OMEGAcorr"&i!=j&FIX==0,tab.est:=sprintf("%s [%s]",signif(est,3),tab.corr)]
     if(rse.cov) pars[panel=="OMEGAcorr"&FIX==0,tab.est:=sprintf("%s (%s)",tab.est,tab.rse)]
 
 


### PR DESCRIPTION
for blocked OMEGA structure, printParameterTable was not able to display off-diagonal correlations values because panel was set to panel=="OMEGA" instead of panel=="OMEGAcorr". For on-diagonal omega elements, panel should be panel=="IIV" so panel=="OMEGA" is actually never a value of panel and thus does not find any matches. 
this bug only affects the display from printParameterTable. createParameterTable is able to appropriately capture the values of off-diagonal correlations